### PR TITLE
Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ A simple clipboard tool for copying and pasting file contents in bash using a te
 ### Option 1: Manual build
 
 ```bash
-g++ -o bash-clipboard bashclipboard.cpp
+g++ -o clipboard bash-clipboard/bashclipboard.cpp
 ```
 
 Move the binary to a global location:
 
 ```bash
-sudo mv bash-clipboard /usr/local/bin/clipboard
+sudo mv clipboard /usr/local/bin/clipboard
 ```
 
 ### Option 2: Using Makefile
 
 ```bash
-make          # builds bash-clipboard
+make          # builds clipboard
 make install  # moves it to /usr/local/bin/clipboard
 make clean    # removes the binary
 ```


### PR DESCRIPTION
## Summary
- update README manual build instructions to use the correct source path and output name
- fix Makefile description in README

## Testing
- `make clean`
- `make`
- `./tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684602445418832d90ad1ab36e55a43b