### PR TITLE
Use std::cin rdbuf for copy

### DIFF
--- a/bash-clipboard/bashclipboard.cpp
+++ b/bash-clipboard/bashclipboard.cpp
@@ -35,10 +35,7 @@ int main(int argc, char* argv[]) {
         }
 
         std::cin >> std::noskipws;
-        char c;
-        while (std::cin >> c) {
-            out.put(c);
-        }
+        out << std::cin.rdbuf();
 
         out.close();
         if (!out) {


### PR DESCRIPTION
## Summary
- simplify stdin copying by using `std::cin.rdbuf()`

## Testing
- `make`
- `./tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846038c2ccc832db75324904cb172c9